### PR TITLE
output benchmark results as JSON for easier processing in Python

### DIFF
--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <cerrno>
 #include <counters.hpp>
 #include <fstream>
@@ -14,7 +12,7 @@
 
 constexpr uint64_t rseed = 48048593;
 
-constexpr uint64_t BENCH_NUM         = 2;
+constexpr uint64_t BENCH_NUM         = 1;
 constexpr uint64_t WARM_UP_COOL_DOWN = 0;
 
 struct RNG {

--- a/include/benchmark.hpp
+++ b/include/benchmark.hpp
@@ -1,20 +1,20 @@
-#ifndef _BENCHMARK_HPP_
-#define _BENCHMARK_HPP_
-#include <counters.hpp>
-#include <sched.h>
-#include <fstream>
+#pragma once
+
 #include <cerrno>
+#include <counters.hpp>
+#include <fstream>
+#include <iostream>
+#include <sched.h>
 #include <string>
 #include <system_error>
-#include <iostream>
 
-#include <random>
 #include <algorithm>
+#include <random>
 #include <sys/mman.h>
 
 constexpr uint64_t rseed = 48048593;
 
-constexpr uint64_t BENCH_NUM         = 1;
+constexpr uint64_t BENCH_NUM         = 2;
 constexpr uint64_t WARM_UP_COOL_DOWN = 0;
 
 struct RNG {
@@ -59,7 +59,8 @@ void benchmark(pa count, const char* str, int cpu, B bench,
     exit(-10);
   }
 
-  stats << str << "\t" << num_counters() << "\t" << BENCH_NUM << std::endl;
+  stats << '{' << "\"name\": \"" << str << "\""
+        << "\", \"counters\": ";
   for (uint64_t i = 0; i < WARM_UP_COOL_DOWN * 2 + BENCH_NUM; i++) {
     bench(count);
 
@@ -85,13 +86,17 @@ void benchmark(pa count, const char* str, B bench,
     exit(-5);
   }
 
-  stats << str << "\t" << num_counters() << "\t" << BENCH_NUM << std::endl;
+  stats << "{\"name\": \"" << str << "\",\"runs\": [";
   for (uint64_t i = 0; i < WARM_UP_COOL_DOWN * 2 + BENCH_NUM; i++) {
     bench(count);
 
-    if (WARM_UP_COOL_DOWN <= i && WARM_UP_COOL_DOWN + BENCH_NUM > i)
+    if (WARM_UP_COOL_DOWN <= i && WARM_UP_COOL_DOWN + BENCH_NUM > i) {
+      if (WARM_UP_COOL_DOWN < i)
+        stats << ", ";
       print_counters(count, stats);
+    }
   }
+  stats << "]}" << std::endl;
 }
 
 #else
@@ -228,5 +233,3 @@ std::vector<uint64_t>* el_file_to_edge_list(const std::string& ELFile,
   graphFile.close();
   return ret;
 }
-
-#endif

--- a/include/graph_benchmark_style.hpp
+++ b/include/graph_benchmark_style.hpp
@@ -171,7 +171,7 @@ void run_algo_p_evolve(
           return graph;
         },
         [edge_list, num_edges, i, evo, chunk_num](Graph* graph) {
-          evo(graph, num_edges / chunk_num * (i - 1), num_edges / chunk_num,
+          evo(graph, num_edges / chunk_num * (i - 1), num_edges / chunk_num * i,
               num_edges / chunk_num, edge_list, i);
         },
         [](Graph* graph) { delete graph; });


### PR DESCRIPTION
example of what this looks like (with multiple samples per benchmark):

```bash
$ ./jaccard -n=100 -m=1 -p=0.15 --out=NON -g=LS_CSR --style=EVOLVE --stats out.txt
```

produces

```json
{"name": "LS_CSR EVOLVE Edit 1/8","runs": [{"cycles": 4411083, "instru": 189245, "l1_dlm": 102623, "l1_dla": 56686}, {"cycles": 352957, "instru": 75373, "l1_dlm": 2528, "l1_dla": 22925}]}
{"name": "LS_CSR EVOLVE Algo 1/8","runs": [{"cycles": 479475, "instru": 477775, "l1_dlm": 185, "l1_dla": 87004}, {"cycles": 470371, "instru": 477775, "l1_dlm": 131, "l1_dla": 87004}]}
{"name": "LS_CSR EVOLVE Edit 2/8","runs": [{"cycles": 75826, "instru": 36936, "l1_dlm": 926, "l1_dla": 10882}, {"cycles": 59316, "instru": 27917, "l1_dlm": 823, "l1_dla": 8362}]}
{"name": "LS_CSR EVOLVE Algo 2/8","runs": [{"cycles": 479307, "instru": 477775, "l1_dlm": 174, "l1_dla": 87004}, {"cycles": 465835, "instru": 477775, "l1_dlm": 109, "l1_dla": 86996}]}
{"name": "LS_CSR EVOLVE Edit 3/8","runs": [{"cycles": 62123, "instru": 28500, "l1_dlm": 793, "l1_dla": 8516}, {"cycles": 35753, "instru": 20983, "l1_dlm": 429, "l1_dla": 6279}]}
{"name": "LS_CSR EVOLVE Algo 3/8","runs": [{"cycles": 476351, "instru": 477775, "l1_dlm": 171, "l1_dla": 86996}, {"cycles": 472293, "instru": 477775, "l1_dlm": 129, "l1_dla": 87012}]}
{"name": "LS_CSR EVOLVE Edit 4/8","runs": [{"cycles": 59524, "instru": 28499, "l1_dlm": 808, "l1_dla": 8519}, {"cycles": 56681, "instru": 28021, "l1_dlm": 817, "l1_dla": 8385}]}
{"name": "LS_CSR EVOLVE Algo 4/8","runs": [{"cycles": 477783, "instru": 477775, "l1_dlm": 178, "l1_dla": 86996}, {"cycles": 472770, "instru": 477775, "l1_dlm": 130, "l1_dla": 87012}]}
{"name": "LS_CSR EVOLVE Edit 5/8","runs": [{"cycles": 38878, "instru": 21413, "l1_dlm": 476, "l1_dla": 6385}, {"cycles": 34373, "instru": 20983, "l1_dlm": 443, "l1_dla": 6273}]}
{"name": "LS_CSR EVOLVE Algo 5/8","runs": [{"cycles": 477314, "instru": 477775, "l1_dlm": 171, "l1_dla": 86996}, {"cycles": 472455, "instru": 477775, "l1_dlm": 130, "l1_dla": 87012}]}
{"name": "LS_CSR EVOLVE Edit 6/8","runs": [{"cycles": 39103, "instru": 21624, "l1_dlm": 469, "l1_dla": 6439}, {"cycles": 35518, "instru": 21079, "l1_dlm": 431, "l1_dla": 6286}]}
{"name": "LS_CSR EVOLVE Algo 6/8","runs": [{"cycles": 478997, "instru": 477775, "l1_dlm": 168, "l1_dla": 86996}, {"cycles": 466775, "instru": 477775, "l1_dlm": 126, "l1_dla": 86996}]}
{"name": "LS_CSR EVOLVE Edit 7/8","runs": [{"cycles": 53838, "instru": 21659, "l1_dlm": 560, "l1_dla": 6440}, {"cycles": 35403, "instru": 21097, "l1_dlm": 441, "l1_dla": 6297}]}
{"name": "LS_CSR EVOLVE Algo 7/8","runs": [{"cycles": 477161, "instru": 477775, "l1_dlm": 217, "l1_dla": 86996}, {"cycles": 466803, "instru": 477775, "l1_dlm": 127, "l1_dla": 86996}]}
{"name": "LS_CSR EVOLVE Edit 8/8","runs": [{"cycles": 39395, "instru": 21640, "l1_dlm": 481, "l1_dla": 6443}, {"cycles": 36108, "instru": 21110, "l1_dlm": 431, "l1_dla": 6291}]}
{"name": "LS_CSR EVOLVE Algo 8/8","runs": [{"cycles": 479158, "instru": 477775, "l1_dlm": 165, "l1_dla": 86996}, {"cycles": 470921, "instru": 477775, "l1_dlm": 144, "l1_dla": 87004}]}
```

where each line is a valid JSON object corresponding to the benchmark.