### PR TITLE
replace llvm arg parsing with boost program options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 
-# LLVM dependency for CLI argument parsing
-find_package(LLVM REQUIRED CONFIG)
-include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
-
 # MPI Dependency
 find_package(MPI REQUIRED)
 include_directories(SYSTEM ${MPI_INCLUDE_PATH})
+
+# Boost Dependency
+find_package(Boost 1.74 COMPONENTS program_options REQUIRED)
 
 set(BUILD_TESTING_SAVED "${BUILD_TESTING}")
 set(BUILD_TESTING OFF)

--- a/microbench/CMakeLists.txt
+++ b/microbench/CMakeLists.txt
@@ -5,5 +5,5 @@ include(${graph-log-sketch_SOURCE_DIR}/cmake/GaloisCompilerOptions.cmake)
 
 # edit scalability
 galois_add_executable(edit-scalability edit_scalability.cpp)
-target_link_libraries(edit-scalability PRIVATE Galois::shmem LLVMSupport)
+target_link_libraries(edit-scalability PRIVATE Galois::shmem Boost::program_options)
 target_include_directories(edit-scalability PRIVATE ${graph-log-sketch_SOURCE_DIR}/include)

--- a/microbench/edit_scalability.cpp
+++ b/microbench/edit_scalability.cpp
@@ -68,9 +68,8 @@ int main(int argc, char const* argv[]) {
        "MorphGraph)") //
       ("algo", po::value<AlgoName>()->default_value(nop),
        "Algorithm to run (nop: do nothing, bfs: compute "
-       "single-source shortest path using BFS)")                              //
-      ("bfs-src", po::value<uint64_t>(), "Source vertex (for BFS algorithm)") //
-      ;
+       "single-source shortest path using BFS)") //
+      ("bfs-src", po::value<uint64_t>(), "Source vertex (for BFS algorithm)");
 
   po::variables_map vm;
   try {


### PR DESCRIPTION
also fixes the parsing of `--graph` and `-g` (instead of `--graph,g`)