### PR TITLE
tweaks to ingest benchmarking

### DIFF
--- a/microbench/edit_scalability.cpp
+++ b/microbench/edit_scalability.cpp
@@ -210,7 +210,7 @@ int main(int argc, char const* argv[]) {
           galois::steal(), galois::loopname("Ingestion"));
     }
 
-    {
+    if (!insertions.empty()) {
       BENCHMARK_SCOPE("Post-ingest for Batch " + std::to_string(batch));
 
       graph->post_ingest();

--- a/microbench/edit_scalability.cpp
+++ b/microbench/edit_scalability.cpp
@@ -206,7 +206,8 @@ int main(int argc, char const* argv[]) {
           galois::iterate(insertions.begin(), insertions.end()),
           [&](std::pair<uint64_t, std::vector<uint64_t>> const& operation) {
             graph->add_edges(operation.first, operation.second);
-          });
+          },
+          galois::steal(), galois::loopname("Ingestion"));
     }
 
     {


### PR DESCRIPTION
* enable work stealing for ingest
* only do post-ingest in rounds where we also do ingest